### PR TITLE
Fix NuGet settings for Iris.sln

### DIFF
--- a/Iris/Iris.sln
+++ b/Iris/Iris.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23011.0
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FrontEndTest", "FrontEndTest\FrontEndTest.csproj", "{A53C9D11-E888-4F88-A3B6-0074C3382748}"
 EndProject

--- a/Iris/IrisCompiler/packages.config
+++ b/Iris/IrisCompiler/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
   <package id="System.Reflection.Metadata" version="1.1.0-alpha-00007" targetFramework="net452" />
 </packages>

--- a/Iris/IrisExtension/packages.config
+++ b/Iris/IrisExtension/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
   <package id="System.Reflection.Metadata" version="1.1.0-alpha-00007" targetFramework="net452" />
 </packages>

--- a/Iris/NuGet.config
+++ b/Iris/NuGet.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c)  Microsoft.  All Rights Reserved.
+  Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ -->
+
+<configuration>
+  <packageSources>
+    <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Update package.config files to latest System.Collection.Immutable and create NuGet.config so users don't need to manually add a package source.
