### PR TITLE
Fix build/tests for Update 1

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -82,7 +82,7 @@
           Outputs="$(NuGetToolPath)">
 
     <DownloadFile FileName="$(NuGetToolPath)"
-                  Address="https://www.nuget.org/nuget.exe"
+                  Address="https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
                   Condition="!Exists('$(NuGetToolPath)')" />
   </Target>
 

--- a/Iris/IrisCompiler/Import/IrisTypeProvider.cs
+++ b/Iris/IrisCompiler/Import/IrisTypeProvider.cs
@@ -100,13 +100,13 @@ namespace IrisCompiler.Import
             }
         }
 
-        IrisType ISignatureTypeProvider<IrisType>.GetTypeFromDefinition(TypeDefinitionHandle handle)
+        IrisType ISignatureTypeProvider<IrisType>.GetTypeFromDefinition(TypeDefinitionHandle handle, bool? isValueType)
         {
             // Iris doesn't define any types that can be referenced.
             return IrisType.Invalid;
         }
 
-        IrisType ISignatureTypeProvider<IrisType>.GetTypeFromReference(TypeReferenceHandle handle)
+        IrisType ISignatureTypeProvider<IrisType>.GetTypeFromReference(TypeReferenceHandle handle, bool? isValueType)
         {
             // We shouldn't be referencing any non-primitive types.
             return IrisType.Invalid;

--- a/Iris/IrisCompiler/IrisCompiler.csproj
+++ b/Iris/IrisCompiler/IrisCompiler.csproj
@@ -38,13 +38,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.1.1.0-alpha-00007\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.2.0-alpha-00016\lib\dotnet\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />

--- a/Iris/IrisCompiler/packages.config
+++ b/Iris/IrisCompiler/packages.config
@@ -1,5 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0-alpha-00007" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net452" />
+  <package id="System.IO" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-alpha-00016" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.0.0" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.0.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net452" />
 </packages>

--- a/Iris/IrisExtension/IrisExtension.csproj
+++ b/Iris/IrisExtension/IrisExtension.csproj
@@ -70,6 +70,7 @@
     <VsdConfigXmlFiles Include="ExpressionCompiler\ExpressionCompiler.vsdconfigxml" />
     <VsdConfigXmlFiles Include="Formatter\Formatter.vsdconfigxml" />
     <VsdConfigXmlFiles Include="FrameDecoder\FrameDecoder.vsdconfigxml" />
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
@@ -90,12 +91,13 @@
       <HintPath>$(DevEnvDir)\Remote Debugger\x86\Microsoft.VisualStudio.Debugger.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.1.1.0-alpha-00007\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.2.0-alpha-00016\lib\dotnet\System.Reflection.Metadata.dll</HintPath>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Private>True</Private>
     </Reference>

--- a/Iris/IrisExtension/app.config
+++ b/Iris/IrisExtension/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Iris/IrisExtension/packages.config
+++ b/Iris/IrisExtension/packages.config
@@ -1,5 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="System.Collections" version="4.0.0" targetFramework="net452" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.1.0-alpha-00007" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net452" />
+  <package id="System.IO" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0-alpha-00016" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.0.0" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.0.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net452" />
 </packages>

--- a/Iris/NuGet.config
+++ b/Iris/NuGet.config
@@ -7,5 +7,6 @@
 <configuration>
   <packageSources>
     <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Fix build and tests to work with Visual Studio 2015 Update 1

1.  Update version of NuGet
1.  Upgrade to latest System.Reflection.Metadata and System.Reflection.Immutable