### PR TITLE
Fix engine registration

### DIFF
--- a/Iris/IrisExtension/Iris.pkgdef
+++ b/Iris/IrisExtension/Iris.pkgdef
@@ -1,4 +1,10 @@
 
+; This key registers the language with the debugger.  The Language string is used in the debugger UI to refer to the language (Call Stack window, for example)
 [$RootKey$\AD7Metrics\ExpressionEvaluator\{3456107B-A1F4-4D47-8E18-7CF2C54559AE}\{5E176682-93DA-497A-A5F0-F1AEE5E18CCE}]
 "Name"="Iris"
 "Language"="Iris"
+
+; Specifies the debug engines supported by the language.  Here we are specifying that Iris can be used when Managed or Mixed Mode debugging.
+[$RootKey$\AD7Metrics\ExpressionEvaluator\{3456107B-A1F4-4D47-8E18-7CF2C54559AE}\{5E176682-93DA-497A-A5F0-F1AEE5E18CCE}\Engine]
+"0"="{449EC4CC-30D2-4032-9256-EE18EB41B62B}"
+"1"="{92EF0900-2251-11D2-B72E-0000F87572EF}"


### PR DESCRIPTION
The AD7Metrics registration was missing the engines supported by Iris.  The missing registration doesn't cause a problem at the moment because there is no language service.  However, if we were to write a language service, conditional breakpoints would no longer work because the debugger UI would assume that they are not supported given no engines supporting conditional breakpoints are mapped to the language. 

Added fix so people copying the sample (and registration) won't run into the problem of breakpoints being unsupported if they have a language service.