### PR TITLE
Update to latest System.Reflection.Metadata

### DIFF
--- a/Iris/IrisCompiler/Import/ImportedField.cs
+++ b/Iris/IrisCompiler/Import/ImportedField.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 using System.Reflection.Metadata;
-using System.Reflection.Metadata.Decoding;
 
 namespace IrisCompiler.Import
 {
@@ -42,7 +41,7 @@ namespace IrisCompiler.Import
             get
             {
                 if (_cachedType == null)
-                    _cachedType = SignatureDecoder.DecodeFieldSignature(_fieldDef.Signature, Module.IrisTypeProvider);
+                    _cachedType = _fieldDef.DecodeSignature(Module.IrisTypeProvider);
 
                 return _cachedType;
             }

--- a/Iris/IrisCompiler/Import/ImportedMethod.cs
+++ b/Iris/IrisCompiler/Import/ImportedMethod.cs
@@ -24,7 +24,7 @@ namespace IrisCompiler.Import
             : base(module, methodDef.Name, declaringType)
         {
             _methodDef = methodDef;
-            _signature = SignatureDecoder.DecodeMethodSignature(_methodDef.Signature, Module.IrisTypeProvider);
+            _signature = methodDef.DecodeSignature(Module.IrisTypeProvider);
         }
 
         public override bool IsPublic

--- a/Iris/IrisCompiler/Import/ImportedModule.cs
+++ b/Iris/IrisCompiler/Import/ImportedModule.cs
@@ -131,7 +131,8 @@ namespace IrisCompiler.Import
         public ImmutableArray<IrisType> DecodeLocalVariableTypes(int mdToken)
         {
             StandaloneSignatureHandle localVarSigHandle = (StandaloneSignatureHandle)MetadataTokens.EntityHandle(mdToken);
-            return SignatureDecoder.DecodeLocalSignature(localVarSigHandle, IrisTypeProvider);
+            StandaloneSignature sig = _reader.GetStandaloneSignature(localVarSigHandle);
+            return sig.DecodeLocalSignature(IrisTypeProvider);
         }
 
         internal ImportedType ResolveType(TypeDefinitionHandle handle)

--- a/Iris/IrisCompiler/IrisCompiler.csproj
+++ b/Iris/IrisCompiler/IrisCompiler.csproj
@@ -43,8 +43,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.1.2.0-alpha-00016\lib\dotnet\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.3.0-rc3-23923\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -86,7 +86,10 @@
     <Compile Include="Variable.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Iris/IrisCompiler/app.config
+++ b/Iris/IrisCompiler/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Iris/IrisCompiler/packages.config
+++ b/Iris/IrisCompiler/packages.config
@@ -8,7 +8,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.2.0-alpha-00016" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.3.0-rc3-23923" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/Iris/IrisExtension/IrisExtension.csproj
+++ b/Iris/IrisExtension/IrisExtension.csproj
@@ -71,7 +71,9 @@
     <VsdConfigXmlFiles Include="Formatter\Formatter.vsdconfigxml" />
     <VsdConfigXmlFiles Include="FrameDecoder\FrameDecoder.vsdconfigxml" />
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
@@ -96,8 +98,8 @@
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reflection.Metadata.1.2.0-alpha-00016\lib\dotnet\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.3.0-rc3-23923\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
       <Private>True</Private>
     </Reference>

--- a/Iris/IrisExtension/packages.config
+++ b/Iris/IrisExtension/packages.config
@@ -8,7 +8,7 @@
   <package id="System.Linq" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.0.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.0.0" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.2.0-alpha-00016" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.3.0-rc3-23923" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.0.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.0.0" targetFramework="net452" />

--- a/Iris/NuGet.config
+++ b/Iris/NuGet.config
@@ -6,7 +6,7 @@
 
 <configuration>
   <packageSources>
-    <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
+    <add key="myget.org dotnet-corefx" value="https://dotnet.myget.org/F/dotnet-core/" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Older version of System.Reflection.Metadata is no longer available.  Moving to later version...
Unfortunately the signature decoder is still not available in released versions so we are still stuck with prerelease.