### PR TITLE
VS 2017 support part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ BuildResults.xml
 intermediate
 *.metaproj
 *.tmp
+*.VC.opendb
+*.VC.db
 packages/
+.vs/
 Microsoft.VisualStudio.Glass
-
+/Iris/Programs/*.dll
+/Iris/Programs/*.exe
+/Iris/Programs/*.pdb

--- a/HelloWorld/Cpp/HelloWorld.sln
+++ b/HelloWorld/Cpp/HelloWorld.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloWorld", "dll\HelloWorld.vcxproj", "{D547DF85-7B84-462C-BCE7-8F166D7C543D}"
-EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vsix", "vsix\vsix.vcxproj", "{0E22D156-940B-431D-945D-51B7DFA08AEF}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "HelloWorld", "dll\HelloWorld.vcxproj", "{D547DF85-7B84-462C-BCE7-8F166D7C543D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/HelloWorld/Cpp/dll/HelloWorld.vcxproj
+++ b/HelloWorld/Cpp/dll/HelloWorld.vcxproj
@@ -14,22 +14,33 @@
     <ProjectGuid>{D547DF85-7B84-462C-BCE7-8F166D7C543D}</ProjectGuid>
     <RootNamespace>HelloWorld</RootNamespace>
     <Keyword>AtlProj</Keyword>
+    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+
+    <!--Try and find an SDK which is installed-->
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' and Exists('$(MSBuildProgramFiles32)\Windows Kits\10\Include\10.0.14393.0\um\WinBase.h')">10.0.14393.0</WindowsTargetPlatformVersion>
+
+    <!--Failing that, fall back to some defaults-->
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' and '$(VisualStudioVersion)' == '15.0'">10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' and '$(VisualStudioVersion)' == '14.0'">10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <ConcordSDKDir>$(VSSDK140Install)VisualStudioIntegration\</ConcordSDKDir>
+    <VSSDKRoot Condition="'$(DevEnvDir)'!='' and Exists('$(DevEnvDir)..\..\VSSDK\VisualStudioIntegration\')">$([System.IO.Path]::GetFullPath('$(DevEnvDir)..\..\VSSDK\'))</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'==''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\VSIP\14.0\@InstallDir)</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'==''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\VSIP\14.0\@InstallDir)</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'!='' and '$(VSSDKRoot.EndsWith(&quot;\&quot;))'=='false'">$(VSSDKRoot)\</VSSDKRoot>
+    <!--Root directory to Concord SDK install; includes the trailing backslash '\'.-->
+    <ConcordSDKDir>$(VSSDKRoot)VisualStudioIntegration\</ConcordSDKDir>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfAtl>Dynamic</UseOfAtl>
-    <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfAtl>Dynamic</UseOfAtl>
-    <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">

--- a/HelloWorld/Cpp/vsix/source.extension.vsixmanifest
+++ b/HelloWorld/Cpp/vsix/source.extension.vsixmanifest
@@ -6,8 +6,11 @@
     <Description xml:space="preserve">C++ HelloWorld Debugger Sample</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 15.0]" />
   </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Debugger" Version="[15.0,)" DisplayName="Visual Studio Debugger" />
+  </Prerequisites>
   <Assets>
     <Asset Type="DebuggerEngineExtension" Path="HelloWorld.vsdconfig" />
   </Assets>

--- a/HelloWorld/Cpp/vsix/vsix.vcxproj
+++ b/HelloWorld/Cpp/vsix/vsix.vcxproj
@@ -28,12 +28,27 @@
     <ProjectGuid>{0E22D156-940B-431D-945D-51B7DFA08AEF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>vsix</RootNamespace>
+    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
+
+    <!--Try and find an SDK which is installed-->
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' and Exists('$(MSBuildProgramFiles32)\Windows Kits\10\Include\10.0.14393.0\um\WinBase.h')">10.0.14393.0</WindowsTargetPlatformVersion>
+
+    <!--Failing that, fall back to some defaults-->
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' and '$(VisualStudioVersion)' == '15.0'">10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' and '$(VisualStudioVersion)' == '14.0'">10.0.10240.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>NONE</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup>
+    <LocalDebuggerCommand>$(DevEnvDir)devenv.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommandArguments>/rootsuffix Exp</LocalDebuggerCommandArguments>
+    <LocalDebuggerWorkingDirectory>$(DevEnvDir)</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerAttach>false</LocalDebuggerAttach>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <!--Provide an empty CoreCompile target to make the build happy-->
   <Target Name="CoreCompile">

--- a/HelloWorld/Cs/HelloWorld.sln
+++ b/HelloWorld/Cs/HelloWorld.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorld", "dll\HelloWorld.csproj", "{9C899D87-5BFA-4886-B701-68C515F1371C}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "vsix", "vsix\vsix.csproj", "{BDC856C1-DC07-4BF0-916E-8FD1419D0ED4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HelloWorld", "dll\HelloWorld.csproj", "{9C899D87-5BFA-4886-B701-68C515F1371C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/HelloWorld/Cs/dll/HelloWorld.csproj
+++ b/HelloWorld/Cs/dll/HelloWorld.csproj
@@ -11,8 +11,13 @@
     <AssemblyName>HelloWorld</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    
+    <VSSDKRoot Condition="'$(DevEnvDir)'!='' and Exists('$(DevEnvDir)..\..\VSSDK\VisualStudioIntegration\')">$([System.IO.Path]::GetFullPath('$(DevEnvDir)..\..\VSSDK\'))</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'==''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\VSIP\14.0\@InstallDir)</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'==''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\VSIP\14.0\@InstallDir)</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'!='' and '$(VSSDKRoot.EndsWith(&quot;\&quot;))'=='false'">$(VSSDKRoot)\</VSSDKRoot>
     <!--Root directory to Concord SDK install; includes the trailing backslash '\'.-->
-    <ConcordSDKDir>$(VSSDK140Install)VisualStudioIntegration\</ConcordSDKDir>
+    <ConcordSDKDir>$(VSSDKRoot)VisualStudioIntegration\</ConcordSDKDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/HelloWorld/Cs/vsix/source.extension.vsixmanifest
+++ b/HelloWorld/Cs/vsix/source.extension.vsixmanifest
@@ -6,8 +6,11 @@
     <Description xml:space="preserve">C# HelloWorld Debugger Sample</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 15.0]" />
   </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Debugger" Version="[15.0,)" DisplayName="Visual Studio Debugger" />
+  </Prerequisites>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
   </Dependencies>

--- a/HelloWorld/Cs/vsix/vsix.csproj
+++ b/HelloWorld/Cs/vsix/vsix.csproj
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
+    <!--Visual Studio will use the value of will use MinimumVisualStudioVersion to detect if a project needs to be updated.
+    To allow the project to be loaded in multiple VS versions, conditionally check the project -->
+    <MinimumVisualStudioVersion Condition="'$(VisualStudioVersion)' == '15.0'">15.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion Condition="'$(VisualStudioVersion)' != '15.0'">14.0</MinimumVisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -41,8 +44,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <!--Define debug settings within the .csproj file so that the 'DevEnvDir' can be used.
-  These macros aren't available in the .csproj.user file. -->
   <PropertyGroup>
     <StartAction>Program</StartAction>
     <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>

--- a/Iris/IrisExtension/IrisExtension.csproj
+++ b/Iris/IrisExtension/IrisExtension.csproj
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <!--Visual Studio will use the value of will use MinimumVisualStudioVersion to detect if a project needs to be updated.
+    To allow the project to be loaded in multiple VS versions, conditionally check the project -->
+    <MinimumVisualStudioVersion Condition="'$(VisualStudioVersion)' == '15.0'">15.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion Condition="'$(VisualStudioVersion)' != '15.0'">14.0</MinimumVisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -47,8 +51,19 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <ConcordSDKDir>$(VSSDK140Install)VisualStudioIntegration\</ConcordSDKDir>
+    <VSSDKRoot Condition="'$(DevEnvDir)'!='' and Exists('$(DevEnvDir)..\..\VSSDK\VisualStudioIntegration\')">$([System.IO.Path]::GetFullPath('$(DevEnvDir)..\..\VSSDK\'))</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'==''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\VSIP\14.0\@InstallDir)</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'==''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\VSIP\14.0\@InstallDir)</VSSDKRoot>
+    <VSSDKRoot Condition="'$(VSSDKRoot)'!='' and '$(VSSDKRoot.EndsWith(&quot;\&quot;))'=='false'">$(VSSDKRoot)\</VSSDKRoot>
+    <!--Root directory to Concord SDK install; includes the trailing backslash '\'.-->
+    <ConcordSDKDir>$(VSSDKRoot)VisualStudioIntegration\</ConcordSDKDir>
     <VsdConfigFile>$(OutputPath)IrisExtension.vsdconfig</VsdConfigFile>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
+    <StartWorkingDirectory>$(DevEnvDir)</StartWorkingDirectory>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AddressComparer.cs" />
@@ -87,21 +102,23 @@
     <Reference Include="Microsoft.VisualStudio.Debugger.Engine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(DevEnvDir)\Microsoft.VisualStudio.Debugger.Engine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Debugger.Metadata, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(DevEnvDir)\Remote Debugger\x86\Microsoft.VisualStudio.Debugger.Metadata.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Reflection.Metadata, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.3.0-rc3-23923\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <ForceIncludeInVSIX>true</ForceIncludeInVSIX>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -116,6 +133,7 @@
     <ProjectReference Include="..\IrisCompiler\IrisCompiler.csproj">
       <Project>{ce570b03-0d8e-466c-9674-e431d60d5e71}</Project>
       <Name>IrisCompiler</Name>
+      <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Iris/IrisExtension/source.extension.vsixmanifest
+++ b/Iris/IrisExtension/source.extension.vsixmanifest
@@ -6,11 +6,14 @@
     <Description xml:space="preserve">Iris Debug Engine Extension Sample</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 15.0]" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Debugger" Version="[15.0,)" DisplayName="Visual Studio Debugger" />
+  </Prerequisites>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%"  Path="Iris.pkgdef" />


### PR DESCRIPTION
With this commit, the "Hello World" projects should now work in VS 2017 RC3 (and probably older versions too).
This is also the first part of support in the IrisExtension. But the fix for that one is more complicated as there are breaking changes in System.Reflection.Metadata. So I don't know if it will even be possible to use the same expression compiler in both (unless of course it didn't use System.Reflection.Metadata).