### PR TITLE
Update samples to use the 16.0 GA Nuget packages

### DIFF
--- a/CppCustomVisualizer/dll/CppCustomVisualizer.vcxproj
+++ b/CppCustomVisualizer/dll/CppCustomVisualizer.vcxproj
@@ -218,10 +218,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\build\Microsoft.VSSDK.Debugger.VSDConfigTool.targets" Condition="Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\build\Microsoft.VSSDK.Debugger.VSDConfigTool.targets')" />
-    <Import Project="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\Microsoft.VSSDK.Debugger.VSDebugEng.targets" Condition="Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\Microsoft.VSSDK.Debugger.VSDebugEng.targets')" />
+    <Import Project="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\build\native\Microsoft.VSSDK.Debugger.VSDebugEng.targets" Condition="Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\build\native\Microsoft.VSSDK.Debugger.VSDebugEng.targets')" />
   </ImportGroup>
   <Target Name="VerifyConcordNugetPackagesRestored" BeforeTargets="PrepareForBuild">
     <Error Condition="!Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\build\Microsoft.VSSDK.Debugger.VSDConfigTool.targets')" Text="Could not find Microsoft.VSSDK.Debugger.VSDConfigTool.targets. Right click on the solution and restore NuGet packages." />
-    <Error Condition="!Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\Microsoft.VSSDK.Debugger.VSDebugEng.targets')" Text="Could not find Microsoft.VSSDK.Debugger.VSDebugEng.targets. Right click on the solution and restore NuGet packages." />
+    <Error Condition="!Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\build\native\Microsoft.VSSDK.Debugger.VSDebugEng.targets')" Text="Could not find Microsoft.VSSDK.Debugger.VSDebugEng.targets. Right click on the solution and restore NuGet packages." />
   </Target>
 </Project>

--- a/CppCustomVisualizer/dll/packages.config
+++ b/CppCustomVisualizer/dll/packages.config
@@ -4,8 +4,8 @@
   ** IMPORTANT!!! **
   * When changing this file, also update packages.props
   -->
-  
-  <package id="Microsoft.VSSDK.Debugger.VSDebugEng" version="16.0.2012201-preview" developmentDependency="true" />
-  <package id="Microsoft.VSSDK.Debugger.VSDConfigTool" version="16.0.2012201-preview" developmentDependency="true" />
+
+  <package id="Microsoft.VSSDK.Debugger.VSDebugEng" version="16.0.2032702" developmentDependency="true" targetFramework="native" />
+  <package id="Microsoft.VSSDK.Debugger.VSDConfigTool" version="16.0.2032702" developmentDependency="true" />
 
 </packages>

--- a/CppCustomVisualizer/dll/packages.version.props
+++ b/CppCustomVisualizer/dll/packages.version.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- NOTE: This needs to stay in sync with packages.config -->
-    <ConcordPackageVersion>16.0.2012201-preview</ConcordPackageVersion>
+    <ConcordPackageVersion>16.0.2032702</ConcordPackageVersion>
   </PropertyGroup>
 </Project>

--- a/HelloWorld/Cpp/dll/HelloWorld.vcxproj
+++ b/HelloWorld/Cpp/dll/HelloWorld.vcxproj
@@ -18,7 +18,7 @@
     <NugetPackagesDirectory>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\packages\))</NugetPackagesDirectory>
   </PropertyGroup>
   <Import Project="packages.version.props" />
-  <Import Project="..\Cpp.props"/>
+  <Import Project="..\Cpp.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfAtl>Dynamic</UseOfAtl>
@@ -143,10 +143,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\build\Microsoft.VSSDK.Debugger.VSDConfigTool.targets" Condition="Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\build\Microsoft.VSSDK.Debugger.VSDConfigTool.targets')" />
-    <Import Project="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\Microsoft.VSSDK.Debugger.VSDebugEng.targets" Condition="Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\Microsoft.VSSDK.Debugger.VSDebugEng.targets')" />
+    <Import Project="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\build\native\Microsoft.VSSDK.Debugger.VSDebugEng.targets" Condition="Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\build\native\Microsoft.VSSDK.Debugger.VSDebugEng.targets')" />
   </ImportGroup>
   <Target Name="VerifyConcordNugetPackagesRestored" BeforeTargets="PrepareForBuild">
     <Error Condition="!Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\build\Microsoft.VSSDK.Debugger.VSDConfigTool.targets')" Text="Could not find Microsoft.VSSDK.Debugger.VSDConfigTool.targets. Right click on the solution and restore NuGet packages." />
-    <Error Condition="!Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\Microsoft.VSSDK.Debugger.VSDebugEng.targets')" Text="Could not find Microsoft.VSSDK.Debugger.VSDebugEng.targets. Right click on the solution and restore NuGet packages." />
+    <Error Condition="!Exists('$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDebugEng.$(ConcordPackageVersion)\build\native\Microsoft.VSSDK.Debugger.VSDebugEng.targets')" Text="Could not find Microsoft.VSSDK.Debugger.VSDebugEng.targets. Right click on the solution and restore NuGet packages." />
   </Target>
 </Project>

--- a/HelloWorld/Cpp/dll/packages.config
+++ b/HelloWorld/Cpp/dll/packages.config
@@ -4,8 +4,7 @@
   ** IMPORTANT!!! **
   * When changing this file, also update packages.props
   -->
-  
-  <package id="Microsoft.VSSDK.Debugger.VSDebugEng" version="16.0.2012201-preview" developmentDependency="true" />
-  <package id="Microsoft.VSSDK.Debugger.VSDConfigTool" version="16.0.2012201-preview" developmentDependency="true" />
 
+  <package id="Microsoft.VSSDK.Debugger.VSDebugEng" version="16.0.2032702" developmentDependency="true" targetFramework="native" />
+  <package id="Microsoft.VSSDK.Debugger.VSDConfigTool" version="16.0.2032702" developmentDependency="true" />
 </packages>

--- a/HelloWorld/Cpp/dll/packages.version.props
+++ b/HelloWorld/Cpp/dll/packages.version.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- NOTE: This needs to stay in sync with packages.config -->
-    <ConcordPackageVersion>16.0.2012201-preview</ConcordPackageVersion>
+    <ConcordPackageVersion>16.0.2032702</ConcordPackageVersion>
   </PropertyGroup>
 </Project>

--- a/HelloWorld/Cs/dll/HelloWorld.csproj
+++ b/HelloWorld/Cs/dll/HelloWorld.csproj
@@ -13,7 +13,7 @@
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <!--This is version of the Concord API packages -->
-    <ConcordPackageVersion>16.0.2012201-preview</ConcordPackageVersion>
+    <ConcordPackageVersion>16.0.2032702</ConcordPackageVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Iris/IrisExtension/IrisExtension.csproj
+++ b/Iris/IrisExtension/IrisExtension.csproj
@@ -33,7 +33,7 @@
     <!--NOTE: Ideally the version of this package would be set to 'ConcordPackageVersion', and ConcordPackageVersion
     would be set to the minimum version of Visual Studio supported by an extension. However, the
     Microsoft.VSSDK.Debugger.VSDConfigTool package is new for VS 16 (Visual Studio 2019).-->
-    <VSDConfigToolVersion>16.0.2012201-preview</VSDConfigToolVersion>
+    <VSDConfigToolVersion>16.0.2032702</VSDConfigToolVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
The finial 16.0 GA nuget packages for Concord extensibility are now on nuget.org. This updates the samples to consume this version.

Note that the GA version of the Microsoft.VSSDK.Debugger.VSDebugEng package has a slightly different directory layout to make the Nuget package manager happy. This update these projects to expect this new layout.