### PR TITLE
Fix small bugs with samples

### DIFF
--- a/CppCustomVisualizer/dll/_EntryPoint.cpp
+++ b/CppCustomVisualizer/dll/_EntryPoint.cpp
@@ -340,7 +340,7 @@ HRESULT CCppCustomVisualizerService::FileTimeToText(const FILETIME& fileTime, CS
         &systemTime,
         nullptr,
         pBuffer,
-        cch
+        allocLength+1
         );
     if (cch == 0)
     {

--- a/CppCustomVisualizer/vsix/source.extension.vsixmanifest
+++ b/CppCustomVisualizer/vsix/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description xml:space="preserve">CppCustomVisualizer Debugger Sample</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 16.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 17.0)" />
   </Installation>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Debugger" Version="[15.0,)" DisplayName="Visual Studio Debugger" />

--- a/HelloWorld/Cpp/vsix/source.extension.vsixmanifest
+++ b/HelloWorld/Cpp/vsix/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description xml:space="preserve">C++ HelloWorld Debugger Sample</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 16.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 17.0)" />
   </Installation>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Debugger" Version="[15.0,)" DisplayName="Visual Studio Debugger" />

--- a/HelloWorld/Cs/vsix/source.extension.vsixmanifest
+++ b/HelloWorld/Cs/vsix/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description xml:space="preserve">C# HelloWorld Debugger Sample</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 16.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 17.0)" />
   </Installation>
   <Prerequisites>
     <Prerequisite Id="Microsoft.VisualStudio.Debugger" Version="[15.0,)" DisplayName="Visual Studio Debugger" />

--- a/Iris/IrisExtension/source.extension.vsixmanifest
+++ b/Iris/IrisExtension/source.extension.vsixmanifest
@@ -6,7 +6,7 @@
     <Description xml:space="preserve">Iris Debug Engine Extension Sample</Description>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 16.0]" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 17.0)" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
- The extension manifest file was using `16.0]` instead of `17.0)` for supported version range, which doesn't including 16.1, 16.2, etc. This fixes #52 
- The CppCustomVisualizer was providing the wrong buffer size to GetDateFormatW. This fixes #51 