### PR TITLE
Update to 17.0.2012801 Concord nuget packages

### DIFF
--- a/CppCustomVisualizer/dll/CppCustomVisualizer.vcxproj
+++ b/CppCustomVisualizer/dll/CppCustomVisualizer.vcxproj
@@ -124,7 +124,7 @@
     <ResourceCompile Include="CppCustomVisualizer.rc" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\content\vsdconfig.xsd">
+    <None Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\build\vsdconfig.xsd">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>

--- a/CppCustomVisualizer/dll/CppCustomVisualizer.vcxproj.filters
+++ b/CppCustomVisualizer/dll/CppCustomVisualizer.vcxproj.filters
@@ -77,7 +77,7 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\content\vsdconfig.xsd">
+    <None Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\build\vsdconfig.xsd">
       <Filter>Concord API %28for reference%29</Filter>
     </None>
   </ItemGroup>

--- a/CppCustomVisualizer/dll/packages.config
+++ b/CppCustomVisualizer/dll/packages.config
@@ -5,7 +5,7 @@
   * When changing this file, also update packages.props
   -->
 
-  <package id="Microsoft.VSSDK.Debugger.VSDebugEng" version="17.0.1110801" developmentDependency="true" targetFramework="native" />
-  <package id="Microsoft.VSSDK.Debugger.VSDConfigTool" version="17.0.1110801" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.Debugger.VSDebugEng" version="17.0.2012801" developmentDependency="true" targetFramework="native" />
+  <package id="Microsoft.VSSDK.Debugger.VSDConfigTool" version="17.0.2012801" developmentDependency="true" />
 
 </packages>

--- a/CppCustomVisualizer/dll/packages.version.props
+++ b/CppCustomVisualizer/dll/packages.version.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- NOTE: This needs to stay in sync with packages.config -->
-    <ConcordPackageVersion>17.0.1110801</ConcordPackageVersion>
+    <ConcordPackageVersion>17.0.2012801</ConcordPackageVersion>
   </PropertyGroup>
 </Project>

--- a/HelloWorld/Cpp/dll/HelloWorld.vcxproj
+++ b/HelloWorld/Cpp/dll/HelloWorld.vcxproj
@@ -121,7 +121,7 @@
     <ResourceCompile Include="HelloWorld.rc" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\content\vsdconfig.xsd">
+    <None Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\build\vsdconfig.xsd">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>

--- a/HelloWorld/Cpp/dll/HelloWorld.vcxproj.filters
+++ b/HelloWorld/Cpp/dll/HelloWorld.vcxproj.filters
@@ -77,7 +77,7 @@
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\content\vsdconfig.xsd">
+    <None Include="$(NugetPackagesDirectory)Microsoft.VSSDK.Debugger.VSDConfigTool.$(ConcordPackageVersion)\build\vsdconfig.xsd">
       <Filter>Concord API %28for reference%29</Filter>
     </None>
   </ItemGroup>

--- a/HelloWorld/Cpp/dll/packages.config
+++ b/HelloWorld/Cpp/dll/packages.config
@@ -5,6 +5,6 @@
   * When changing this file, also update packages.props
   -->
 
-  <package id="Microsoft.VSSDK.Debugger.VSDebugEng" version="17.0.1110801" developmentDependency="true" targetFramework="native" />
-  <package id="Microsoft.VSSDK.Debugger.VSDConfigTool" version="17.0.1110801" developmentDependency="true" />
+  <package id="Microsoft.VSSDK.Debugger.VSDebugEng" version="17.0.2012801" developmentDependency="true" targetFramework="native" />
+  <package id="Microsoft.VSSDK.Debugger.VSDConfigTool" version="17.0.2012801" developmentDependency="true" />
 </packages>

--- a/HelloWorld/Cpp/dll/packages.version.props
+++ b/HelloWorld/Cpp/dll/packages.version.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- NOTE: This needs to stay in sync with packages.config -->
-    <ConcordPackageVersion>17.0.1110801</ConcordPackageVersion>
+    <ConcordPackageVersion>17.0.2012801</ConcordPackageVersion>
   </PropertyGroup>
 </Project>

--- a/HelloWorld/Cs/dll/HelloWorld.csproj
+++ b/HelloWorld/Cs/dll/HelloWorld.csproj
@@ -13,7 +13,7 @@
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <FileAlignment>512</FileAlignment>
     <!--This is version of the Concord API packages -->
-    <ConcordPackageVersion>17.0.1110801</ConcordPackageVersion>
+    <ConcordPackageVersion>17.0.2012801</ConcordPackageVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Iris/IrisExtension/IrisExtension.csproj
+++ b/Iris/IrisExtension/IrisExtension.csproj
@@ -8,9 +8,9 @@
     <VsdConfigFile>bin\$(Configuration)\$(TargetFramework)\IrisExtension.vsdconfig</VsdConfigFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine" Version="17.0.1110801" />
-    <PackageReference Include="Microsoft.VisualStudio.Debugger.Metadata" Version="17.0.1110801" />
-    <PackageReference Include="Microsoft.VSSDK.Debugger.VSDConfigTool" Version="17.0.1110801">
+    <PackageReference Include="Microsoft.VisualStudio.Debugger.Engine" Version="17.0.2012801" />
+    <PackageReference Include="Microsoft.VisualStudio.Debugger.Metadata" Version="17.0.2012801" />
+    <PackageReference Include="Microsoft.VSSDK.Debugger.VSDConfigTool" Version="17.0.2012801">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
This PR updates this repo to use the 17.0.2012801 nuget packages. These are packages that are still for the 17.0 release, but have the following fixes:

* Addresses #74 by moving vsdconfig.xsd from the 'content' folder to the 'build' folder
* Fixes incremental build after updating a .vsdconfigxml file
* Updates the Microsoft.VisualStudio.Debugger.Metadata and Microsoft.VisualStudio.Debugger.Engine to remove a few classes that were incorrectly declare as `public` that should have been internal. These were all shim classes needed to run on early versions of .NET Core -- 
    * Microsoft.VisualStudio.Debugger.Engine: 
         * `DebugShim` (in the global namespace)
         * `CultureInfoHelper` (in the global namespace)
         * `System.Runtime.InteropServices.ComAliasNameAttribute`
    * Microsoft.VisualStudio.Debugger.Metadata: 
        * `Microsoft.VisualStudio.Debugger.Metadata.MissingFieldException`
        * `Microsoft.VisualStudio.Debugger.Metadata.MissingMethodException`
        * `Microsoft.VisualStudio.Debugger.Metadata.TypeExtensions`
        * `Microsoft.VisualStudio.Debugger.Metadata.COMExceptionExtensions`