### PR TITLE
VSSDK.BuildTools 17.0.5232 -> 17.3.2093

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+    # Run this workflow manually from the Actions tab
+    workflow_dispatch:
+
 jobs:
   windows_build:
     strategy:

--- a/Iris/vsix/vsix.csproj
+++ b/Iris/vsix/vsix.csproj
@@ -59,7 +59,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2093">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This fixes the issue of:
 C:\Users\runneradmin\.nuget\packages\microsoft.vssdk.buildtools\17.0.5232\tools\VSSDK\Microsoft.VsSDK.targets(829,5): error MSB4018: The "GetDeploymentPathFromVsixManifest" task failed unexpectedly. [D:\a\ConcordExtensibilitySamples\ConcordExtensibilitySamples\Iris\vsix\vsix.csproj]
       C:\Users\runneradmin\.nuget\packages\microsoft.vssdk.buildtools\17.0.5232\tools\VSSDK\Microsoft.VsSDK.targets(829,5): error MSB4018: System.AggregateException: One or more errors occurred. ---> System.NullReferenceException: Object reference not set to an instance of an object. [D:\a\ConcordExtensibilitySamples\ConcordExtensibilitySamples\Iris\vsix\vsix.csproj]

Add manual trigger for Github Actions