### PR TITLE
Move Iris sample from net5.0 to net6.0

### DIFF
--- a/Iris/FrontEndTest/FrontEndTest.csproj
+++ b/Iris/FrontEndTest/FrontEndTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Iris/IrisCompiler/CompilerContext.cs
+++ b/Iris/IrisCompiler/CompilerContext.cs
@@ -156,7 +156,7 @@ namespace IrisCompiler
             // This sample just uses the same assemblies as the compiler is running against.
             // This is not ideal for .NET Core -- normally in .NET Core compilation is done
             // against reference assemblies. For example, the assemblies in
-            // C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0\ref\net5.0
+            // C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\5.0.0\ref\net6.0
             // Instead this will compile against implementation assemblies, which could cause
             // problems in the future.
 

--- a/Iris/Programs/TicTacToe.csproj
+++ b/Iris/Programs/TicTacToe.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Iris/Programs/TicTacToe.runtimeconfig.json
+++ b/Iris/Programs/TicTacToe.runtimeconfig.json
@@ -1,9 +1,9 @@
 {
   "runtimeOptions": {
-    "tfm": "net5.0",
+    "tfm": "net6.0",
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "5.0.0"
+      "version": "6.0.0"
     }
   }
 }

--- a/Iris/Programs/build.cmd
+++ b/Iris/Programs/build.cmd
@@ -6,7 +6,7 @@ popd
 set CmdCompilerDir=%IrisRoot%\ic
 set RuntimeDir=%IrisRoot%\IrisRuntime
 set BuiltConfig=Debug
-set TargetFramework=net5.0
+set TargetFramework=net6.0
 if exist %CmdCompilerDir%\bin\%TargetFramework%\Release\ic.exe set BuiltConfig=Release
 set CmdCompilerPath=%CmdCompilerDir%\bin\%BuiltConfig%\%TargetFramework%\ic.exe
 set RuntimePath=%RuntimeDir%\bin\%BuiltConfig%\IrisRuntime.dll

--- a/Iris/ic/ic.csproj
+++ b/Iris/ic/ic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Iris/xplat-package/xplat-package.csproj
+++ b/Iris/xplat-package/xplat-package.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>xplat_package</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
The Iris sample was still using .NET 5, which is no longer supported. This updates it to use .NET 6.