### PR TITLE
Fix Code Analysis issues

### DIFF
--- a/CppCustomVisualizer/dll/_EntryPoint.cpp
+++ b/CppCustomVisualizer/dll/_EntryPoint.cpp
@@ -350,7 +350,7 @@ HRESULT CCppCustomVisualizerService::FileTimeToText(const FILETIME& fileTime, CS
         return WIN32_LAST_ERROR();
     }
 
-    pBuffer += ((int64_t)cch-1); // '-1' is to convert from a character count (including null terminator) to a length
+    pBuffer += ((size_t)cch-1); // '-1' is to convert from a character count (including null terminator) to a length
     int remainaingLength = allocLength - (cch-1);
 
     // Add a space between the date and the time

--- a/CppCustomVisualizer/dll/_EntryPoint.cpp
+++ b/CppCustomVisualizer/dll/_EntryPoint.cpp
@@ -350,7 +350,7 @@ HRESULT CCppCustomVisualizerService::FileTimeToText(const FILETIME& fileTime, CS
         return WIN32_LAST_ERROR();
     }
 
-    pBuffer += ((int64_t)cch-1); // '-1' is to convert from a character count (including null terminator) to a length
+    pBuffer += ((DWORD)cch-1); // '-1' is to convert from a character count (including null terminator) to a length
     int remainaingLength = allocLength - (cch-1);
 
     // Add a space between the date and the time

--- a/CppCustomVisualizer/dll/_EntryPoint.cpp
+++ b/CppCustomVisualizer/dll/_EntryPoint.cpp
@@ -54,7 +54,8 @@ HRESULT STDMETHODCALLTYPE CCppCustomVisualizerService::EvaluateVisualizedExpress
     CString strEditableValue;
 
     // If we are formatting a pointer, we want to also show the address of the pointer
-    if (pRootVisualizedExpression->Type() != nullptr && wcschr(pRootVisualizedExpression->Type()->Value(), '*') != nullptr)
+    CComPtr<DkmString> pType = pRootVisualizedExpression->Type();
+    if (pType != nullptr && wcschr(pType->Value(), '*') != nullptr)
     {
         // Make the editable value just the pointer string
         UINT64 address = pPointerValueHome->Address();
@@ -225,6 +226,7 @@ HRESULT STDMETHODCALLTYPE CCppCustomVisualizerService::UseDefaultEvaluationBehav
     }
 
     CComPtr<DkmEvaluationResult> pEEEvaluationResult;
+    #pragma warning(suppress : 6387) // 'pLanguageExpression' could be 0
     hr = pVisualizedExpression->EvaluateExpressionCallback(
         pInspectionContext,
         pLanguageExpression,
@@ -348,7 +350,7 @@ HRESULT CCppCustomVisualizerService::FileTimeToText(const FILETIME& fileTime, CS
         return WIN32_LAST_ERROR();
     }
 
-    pBuffer += (cch-1L); // '-1' is to convert from a character count (including null terminator) to a length
+    pBuffer += ((int64_t)cch-1); // '-1' is to convert from a character count (including null terminator) to a length
     int remainaingLength = allocLength - (cch-1);
 
     // Add a space between the date and the time

--- a/CppCustomVisualizer/dll/_EntryPoint.cpp
+++ b/CppCustomVisualizer/dll/_EntryPoint.cpp
@@ -350,7 +350,7 @@ HRESULT CCppCustomVisualizerService::FileTimeToText(const FILETIME& fileTime, CS
         return WIN32_LAST_ERROR();
     }
 
-    pBuffer += ((DWORD)cch-1); // '-1' is to convert from a character count (including null terminator) to a length
+    pBuffer += ((int64_t)cch-1); // '-1' is to convert from a character count (including null terminator) to a length
     int remainaingLength = allocLength - (cch-1);
 
     // Add a space between the date and the time

--- a/CppCustomVisualizer/dll/dllmain.cpp
+++ b/CppCustomVisualizer/dll/dllmain.cpp
@@ -22,7 +22,8 @@ STDAPI DllCanUnloadNow(void)
 }
 
 // Returns a class factory to create an object of the requested type
-STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
+_Check_return_
+STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID FAR* ppv)
 {
     return _AtlModule.DllGetClassObject(rclsid, riid, ppv);
 }

--- a/CppCustomVisualizer2/dll/ChildVisualizer.cpp
+++ b/CppCustomVisualizer2/dll/ChildVisualizer.cpp
@@ -20,6 +20,7 @@ HRESULT CChildVisualizer::Initialize(
 HRESULT CChildVisualizer::CreateEvaluationResult(
     _In_ DkmString* pName,
     _In_ DkmString* pFullName,
+    _In_opt_ DkmString* pType,
     _In_ DkmRootVisualizedExpressionFlags_t flags,
     _In_opt_ DkmVisualizedExpression* pParent,
     _In_ DkmInspectionContext* pInspectionContext,

--- a/CppCustomVisualizer2/dll/ChildVisualizer.cpp
+++ b/CppCustomVisualizer2/dll/ChildVisualizer.cpp
@@ -64,7 +64,7 @@ HRESULT CChildVisualizer::CreateEvaluationResult(
         DkmEvaluationResultFlags::Expandable | DkmEvaluationResultFlags::ReadOnly,
         pValue,
         pValue,
-        nullptr,
+        pType,
         DkmEvaluationResultCategory::Class,
         DkmEvaluationResultAccessType::None,
         DkmEvaluationResultStorageType::None,

--- a/CppCustomVisualizer2/dll/ChildVisualizer.cpp
+++ b/CppCustomVisualizer2/dll/ChildVisualizer.cpp
@@ -20,7 +20,6 @@ HRESULT CChildVisualizer::Initialize(
 HRESULT CChildVisualizer::CreateEvaluationResult(
     _In_ DkmString* pName,
     _In_ DkmString* pFullName,
-    _In_ DkmString* pType,
     _In_ DkmRootVisualizedExpressionFlags_t flags,
     _In_opt_ DkmVisualizedExpression* pParent,
     _In_ DkmInspectionContext* pInspectionContext,
@@ -64,7 +63,7 @@ HRESULT CChildVisualizer::CreateEvaluationResult(
         DkmEvaluationResultFlags::Expandable | DkmEvaluationResultFlags::ReadOnly,
         pValue,
         pValue,
-        pType,
+        nullptr,
         DkmEvaluationResultCategory::Class,
         DkmEvaluationResultAccessType::None,
         DkmEvaluationResultStorageType::None,

--- a/CppCustomVisualizer2/dll/ChildVisualizer.h
+++ b/CppCustomVisualizer2/dll/ChildVisualizer.h
@@ -36,7 +36,6 @@ public:
     HRESULT STDMETHODCALLTYPE CreateEvaluationResult(
         _In_ DkmString* pName,
         _In_ DkmString* pFullName,
-        _In_ DkmString* pType,
         _In_ Evaluation::DkmRootVisualizedExpressionFlags_t flags,
         _In_opt_ Evaluation::DkmVisualizedExpression* pParent,
         _In_ Evaluation::DkmInspectionContext* pInspectionContext,

--- a/CppCustomVisualizer2/dll/ChildVisualizer.h
+++ b/CppCustomVisualizer2/dll/ChildVisualizer.h
@@ -36,6 +36,7 @@ public:
     HRESULT STDMETHODCALLTYPE CreateEvaluationResult(
         _In_ DkmString* pName,
         _In_ DkmString* pFullName,
+        _In_opt_ DkmString* pType,
         _In_ Evaluation::DkmRootVisualizedExpressionFlags_t flags,
         _In_opt_ Evaluation::DkmVisualizedExpression* pParent,
         _In_ Evaluation::DkmInspectionContext* pInspectionContext,

--- a/CppCustomVisualizer2/dll/RootVisualizer.cpp
+++ b/CppCustomVisualizer2/dll/RootVisualizer.cpp
@@ -5,7 +5,7 @@
 
 HRESULT CRootVisualizer::Initialize(
     _In_ DkmVisualizedExpression* pVisualizedExpression,
-    _In_ unsigned int size,
+    _In_ unsigned long long size,
     _In_ bool isPointer)
 {
     m_pVisualizedExpression = pVisualizedExpression;
@@ -33,7 +33,7 @@ HRESULT CRootVisualizer::CreateEvaluationResult(_In_ DkmVisualizedExpression* pV
 
     CString evalText;
     bool isPointer = (pType != nullptr && wcschr(pType->Value(), '*') != nullptr);
-    unsigned int sizeA;
+    unsigned long long sizeA;
     hr = GetSize(
         pVisualizedExpression,
         pFullName,
@@ -46,7 +46,7 @@ HRESULT CRootVisualizer::CreateEvaluationResult(_In_ DkmVisualizedExpression* pV
         return hr;
     }
 
-    unsigned int sizeB;
+    unsigned long long sizeB;
     hr = GetSize(
         pVisualizedExpression,
         pFullName,
@@ -114,7 +114,7 @@ HRESULT CRootVisualizer::CreateEvaluationResult(
     }
 
     CString strValue;
-    strValue.Format(L"Size = %lu", m_size);
+    strValue.Format(L"Size = %llu", m_size);
 
     CString strEditableValue;
 
@@ -207,7 +207,7 @@ HRESULT CRootVisualizer::GetChildren(
 
     CComPtr<DkmEvaluationResultEnumContext> pEnumContext;
     hr = DkmEvaluationResultEnumContext::Create(
-        m_size,
+        (DWORD) min(m_size, (unsigned long long)UINT_MAX),
         m_pVisualizedExpression->StackFrame(),
         pInspectionContext,
         this,
@@ -271,6 +271,7 @@ HRESULT CRootVisualizer::GetItems(
         hr = pChildVisualizer->CreateEvaluationResult(
             pChildName,
             pChildFullName,
+            nullptr,
             DkmRootVisualizedExpressionFlags::None,
             m_pVisualizedExpression,
             m_pVisualizedExpression->InspectionContext(),
@@ -329,7 +330,7 @@ HRESULT CRootVisualizer::GetSize(
     _In_ DkmString* pFullName,
     _In_ LPCWSTR pMemberName,
     _In_ bool rootIsPointer,
-    _Out_ unsigned int* pSize
+    _Out_ unsigned long long* pSize
 )
 {
     HRESULT hr = S_OK;
@@ -388,7 +389,7 @@ HRESULT CRootVisualizer::GetSize(
 
     LPCWSTR sizeStr = pValue->Value();
     LPWSTR endPtr;
-    *pSize = wcstoul(sizeStr, &endPtr, 0);
+    *pSize = wcstoull(sizeStr, &endPtr, 0);
     if (sizeStr == endPtr)
     {
         return E_FAIL;

--- a/CppCustomVisualizer2/dll/RootVisualizer.cpp
+++ b/CppCustomVisualizer2/dll/RootVisualizer.cpp
@@ -5,7 +5,7 @@
 
 HRESULT CRootVisualizer::Initialize(
     _In_ DkmVisualizedExpression* pVisualizedExpression,
-    _In_ unsigned long long size,
+    _In_ unsigned int size,
     _In_ bool isPointer)
 {
     m_pVisualizedExpression = pVisualizedExpression;
@@ -33,7 +33,7 @@ HRESULT CRootVisualizer::CreateEvaluationResult(_In_ DkmVisualizedExpression* pV
 
     CString evalText;
     bool isPointer = (pType != nullptr && wcschr(pType->Value(), '*') != nullptr);
-    unsigned long long sizeA;
+    unsigned int sizeA;
     hr = GetSize(
         pVisualizedExpression,
         pFullName,
@@ -46,7 +46,7 @@ HRESULT CRootVisualizer::CreateEvaluationResult(_In_ DkmVisualizedExpression* pV
         return hr;
     }
 
-    unsigned long long sizeB;
+    unsigned int sizeB;
     hr = GetSize(
         pVisualizedExpression,
         pFullName,
@@ -114,7 +114,7 @@ HRESULT CRootVisualizer::CreateEvaluationResult(
     }
 
     CString strValue;
-    strValue.Format(L"Size = %llu", m_size);
+    strValue.Format(L"Size = %lu", m_size);
 
     CString strEditableValue;
 
@@ -261,13 +261,16 @@ HRESULT CRootVisualizer::GetItems(
 
         CComObject<CChildVisualizer>* pChildVisualizer;
         CComObject<CChildVisualizer>::CreateInstance(&pChildVisualizer);
+        if (pChildVisualizer == NULL)
+        {
+            return E_OUTOFMEMORY;
+        }
         pChildVisualizer->Initialize(m_pVisualizedExpression, m_size, i, m_fIsPointer);
 
         CComPtr<DkmEvaluationResult> pEvaluationResult;
         hr = pChildVisualizer->CreateEvaluationResult(
             pChildName,
             pChildFullName,
-            nullptr,
             DkmRootVisualizedExpressionFlags::None,
             m_pVisualizedExpression,
             m_pVisualizedExpression->InspectionContext(),
@@ -326,7 +329,7 @@ HRESULT CRootVisualizer::GetSize(
     _In_ DkmString* pFullName,
     _In_ LPCWSTR pMemberName,
     _In_ bool rootIsPointer,
-    _Out_ unsigned long long* pSize
+    _Out_ unsigned int* pSize
 )
 {
     HRESULT hr = S_OK;
@@ -385,7 +388,7 @@ HRESULT CRootVisualizer::GetSize(
 
     LPCWSTR sizeStr = pValue->Value();
     LPWSTR endPtr;
-    *pSize = wcstoull(sizeStr, &endPtr, 0);
+    *pSize = wcstoul(sizeStr, &endPtr, 0);
     if (sizeStr == endPtr)
     {
         return E_FAIL;

--- a/CppCustomVisualizer2/dll/RootVisualizer.h
+++ b/CppCustomVisualizer2/dll/RootVisualizer.h
@@ -10,7 +10,7 @@ class ATL_NO_VTABLE __declspec(uuid("1b029bbd-27fa-4872-b27a-bad9a22d6603")) CRo
 {
 private:
     CComPtr<DkmVisualizedExpression> m_pVisualizedExpression;
-    unsigned int m_size;
+    unsigned long long m_size;
     bool m_fIsPointer;
 
 public:
@@ -28,7 +28,7 @@ public:
 
     HRESULT STDMETHODCALLTYPE Initialize(
         _In_ DkmVisualizedExpression* pVisualizedExpression,
-        _In_ unsigned int size,
+        _In_ unsigned long long size,
         _In_ bool isPointer
     );
 
@@ -67,7 +67,7 @@ protected:
         _In_ DkmString* pFullName,
         _In_ LPCWSTR pMemberName,
         _In_ bool rootIsPointer,
-        _Out_ unsigned int* pSize
+        _Out_ unsigned long long* pSize
     );
 
     HRESULT STDMETHODCALLTYPE _InternalQueryInterface(REFIID riid, void** ppvObject)

--- a/CppCustomVisualizer2/dll/RootVisualizer.h
+++ b/CppCustomVisualizer2/dll/RootVisualizer.h
@@ -10,7 +10,7 @@ class ATL_NO_VTABLE __declspec(uuid("1b029bbd-27fa-4872-b27a-bad9a22d6603")) CRo
 {
 private:
     CComPtr<DkmVisualizedExpression> m_pVisualizedExpression;
-    unsigned long long m_size;
+    unsigned int m_size;
     bool m_fIsPointer;
 
 public:
@@ -28,7 +28,7 @@ public:
 
     HRESULT STDMETHODCALLTYPE Initialize(
         _In_ DkmVisualizedExpression* pVisualizedExpression,
-        _In_ unsigned long long size,
+        _In_ unsigned int size,
         _In_ bool isPointer
     );
 
@@ -67,7 +67,7 @@ protected:
         _In_ DkmString* pFullName,
         _In_ LPCWSTR pMemberName,
         _In_ bool rootIsPointer,
-        _Out_ unsigned long long* pSize
+        _Out_ unsigned int* pSize
     );
 
     HRESULT STDMETHODCALLTYPE _InternalQueryInterface(REFIID riid, void** ppvObject)

--- a/CppCustomVisualizer2/dll/dllmain.cpp
+++ b/CppCustomVisualizer2/dll/dllmain.cpp
@@ -22,7 +22,8 @@ STDAPI DllCanUnloadNow(void)
 }
 
 // Returns a class factory to create an object of the requested type
-STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
+_Check_return_
+STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID FAR* ppv)
 {
     return _AtlModule.DllGetClassObject(rclsid, riid, ppv);
 }

--- a/HelloWorld/Cpp/dll/dllmain.cpp
+++ b/HelloWorld/Cpp/dll/dllmain.cpp
@@ -22,7 +22,8 @@ STDAPI DllCanUnloadNow(void)
 }
 
 // Returns a class factory to create an object of the requested type
-STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
+_Check_return_
+STDAPI  DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID FAR* ppv)
 {
     return _AtlModule.DllGetClassObject(rclsid, riid, ppv);
 }


### PR DESCRIPTION
Non-trivial fixes:
For `CRootVisualizer::m_size`, we were storing the 4 byte unsigned int as a 8-byte unsigned long long. Even though the API that it comes from uses unsigned int, and the API we use it for uses an unsigned int. So I just converted the whole thing to use unsigned int.

For `CChildVisualizer::CreateEvaluationResult`, we were passing in `pType` even though `pType` is always null. I just removed `pType` altogether and just pass in null.

Other fixes were simple (1 suppression, 1 cast to 64 bit int, 3 needed to have matching SAL notation as their declaration).