### PR TITLE
Update __debugbreak comments in TargetApp.cpp

### DIFF
--- a/CppCustomVisualizer/TargetApp/TargetApp.cpp
+++ b/CppCustomVisualizer/TargetApp/TargetApp.cpp
@@ -35,7 +35,7 @@ int wmain(int argc, WCHAR* argv[])
 
     FILETIME FTZero = {};
 
-    __debugbreak(); // program will stop here. Evaluate 'creationTime' and 'pPointerTest' in the locals or watch window.
+    __debugbreak(); // program will stop here. Evaluate one of the local variables (ex: 'creationTime') in the locals or watch window.
     std::cout << "Test complete\n";
 
     return 0;

--- a/CppCustomVisualizer2/TargetApp/TargetApp.cpp
+++ b/CppCustomVisualizer2/TargetApp/TargetApp.cpp
@@ -13,7 +13,7 @@ int wmain(int argc, WCHAR* argv[])
     sample.a = { 1, 2, 3, 4, 5 };
     sample.b = { 5, 4, 3, 2, 1 };
 
-    __debugbreak(); // program will stop here. Evaluate 'creationTime' and 'pPointerTest' in the locals or watch window.
+    __debugbreak(); // program will stop here. Evaluate 'sample' in the locals or watch window.
     std::cout << "Test complete\n";
 
     return 0;


### PR DESCRIPTION
The two TargetApp.cpp files had comments about what variables to evaluate which were incorrect. This updates them.

This fixes #105
