### PR TITLE
Update vc tools for v145

### DIFF
--- a/build/targets/Cpp.props
+++ b/build/targets/Cpp.props
@@ -11,7 +11,8 @@ of Visual Studio.
     <PlatformToolset>v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '16.0'">v142</PlatformToolset>
-    <PlatformToolset Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '17.0'))">v143</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' == '17.0'">v143</PlatformToolset>
+    <PlatformToolset Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '18.0'))">v145</PlatformToolset>
 
     <!--In Visual Studio 16+, use the default Windows10 SDK-->
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' and $([MSBuild]::VersionGreaterThanOrEquals('$(VisualStudioVersion)', '16.0'))">10.0</WindowsTargetPlatformVersion>


### PR DESCRIPTION
I kicked the tires on all of our samples in 2026 Insiders and things appear to be working. Update the default PlatformToolset for 2026 to get rid of the update prompt on solution open. 

I didn't update any of the vsixmanifest InstallationTarget version boundaries as it doesn't seem to matter. 